### PR TITLE
Test if sendmail is already installed before installing postfix

### DIFF
--- a/bin/preinstall
+++ b/bin/preinstall
@@ -34,7 +34,10 @@ install_postfix_server() {
 
 case "$(wiz_get "smtp/autoinstall")" in
 	"sendmail")
-		install_postfix_server
+		if ! [ -x "$(command -v sendmail)" ]; then
+			echo 'Sendmail not found in path. Installing postfix'
+			install_postfix_server
+		fi
 		;;
 	*)
 		;;


### PR DESCRIPTION
Uses the POSIX compliant `command -v` to check whether the `sendmail` executable is in path: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html

https://community.openproject.com/projects/openproject/work_packages/26458